### PR TITLE
fix: claymore image that prevents empty wallet

### DIFF
--- a/general_whitelist.json
+++ b/general_whitelist.json
@@ -21,7 +21,7 @@
   },
   "docker.io/sonm/eth-claymore": {
     "allowed_hashes": [
-      "sha256:a6c34e26186c2dc72f4dc24b1b75dc51e1e22f120efd9525491886c76bc30b06"
+      "sha256:6ed90b8b5dd22b564a314e788d8e6bb07a2b8d073877ca4264502b6ed9fdf988"
     ]
   },
   "docker.io/sonm/redshift3d": {


### PR DESCRIPTION
Updated image's entrypoint now [checks](https://github.com/sonm-io/claymore-docker/commit/b18ff0359af248eb45299dd85a953c72fb3a3c4e#diff-1b0c2b516b83393edb7200ad5ff12181R23) that the user passed their wallet address, otherwise - crash with a message. 