### PR TITLE
fix: adapt claymore image to be able to run with dwarf pool

### DIFF
--- a/general_whitelist.json
+++ b/general_whitelist.json
@@ -26,6 +26,7 @@
   },
   "docker.io/sonm/eth-claymore": {
     "allowed_hashes": [
+      "sha256:27cbef25286cedbdeabeaca1dba0e59ceb50d44b3c8c84dbd92093fc9a129f0a",
       "sha256:28b4b647e6f1acac78282f0cdeac8aaa6f85c3c15e4c016298fb6d618fb53c29",
       "sha256:8c636b59b7cb7ebd96f139c880e85a84ca9ff689cbd2fffa6187ffcaf4cd470f"
     ]

--- a/sonm-claymore/run.sh
+++ b/sonm-claymore/run.sh
@@ -16,11 +16,7 @@ fi
 
 # USER-defined params
 SONM_POOL="${POOL:-eth-eu1.nanopool.org:9999}"
-SONM_WORKER="${WORKER:-sonm_worker}"
-SONM_EMAIL="${EMAIL:-johndoe@foobar.baz}"
-
 SONM_PASC_POOL="${PASC_POOL:-stratum+tcp://pasc-eu1.nanopool.org:15555}"
-SONM_PASC_PAYMENTID="${PASC_PAYMENTID:-0}"
 
 if [[ -z "$WALLET" ]]; then
     echo "Please set env-variable 'WALLET' for mined funds."
@@ -30,10 +26,9 @@ fi
 PASC_PARAMS="-mode 1"
 if [[ ! -z "$PASC_ADDRESS" ]]; then
     echo "Enabling PascalCoin mining"
-    PASC_PARAMS="-dpool ${SONM_PASC_POOL} -dwal ${PASC_ADDRESS}.${SONM_PASC_PAYMENTID}.${SONM_WORKER}/${SONM_EMAIL}"
+    PASC_PARAMS="-dpool ${SONM_PASC_POOL} -dwal ${PASC_ADDRESS}"
 fi
 
-ETH_PARAMS="-epool ${SONM_POOL} -ewal ${WALLET}/${SONM_WORKER}/${SONM_EMAIL} -epsw x"
-
+ETH_PARAMS="-epool ${SONM_POOL} -ewal ${WALLET} -epsw x"
 
 /home/claymore/ethdcrminer64 -ftime 10 ${ETH_PARAMS} ${PASC_PARAMS}


### PR DESCRIPTION
This commit allows to explicitly pass pool and wallet params,
not built it inside the `run.sh`.