### PR TITLE
fix: tune monero CPU miner options

### DIFF
--- a/general_whitelist.json
+++ b/general_whitelist.json
@@ -11,7 +11,7 @@
   },
   "docker.io/sonm/monero-cpu": {
     "allowed_hashes": [
-      "sha256:b69dbc581b40b54d5560ce6b9e9ad1b453b2e4e4a15c9194090ccfba5a5732d3"
+      "sha256:cbf601b22c90993c44a6415032471538f4e55fa53e8a2ed8e45bcf870350da52"
     ]
   },
   "docker.io/sonm/monero-amd": {

--- a/monero-cpu/run.sh
+++ b/monero-cpu/run.sh
@@ -12,4 +12,6 @@ fi
 /miner/xmrig -a cryptonight \
     --url ${SONM_POOL} \
     --user ${XMR_ADDR} \
-    --rig-id=${WORKER}
+    --rig-id=${WORKER} \
+    --print-time=10 \
+    --no-color


### PR DESCRIPTION
- Color output disabled.
- Report hashrate every 10 seconds.